### PR TITLE
make directory only when not already present

### DIFF
--- a/generate-matrix.sh
+++ b/generate-matrix.sh
@@ -2,6 +2,6 @@
 
 dir="$1-$2-$3"
 
-mkdir $dir
+mkdir -p $dir
 
 time ../generate-kmer-count-matrix.py --kmerlen $2 --num-sample $3 --seed-zero --keep-jf --jf-storage-dir $dir/jf-dir/ --taxa-file $dir/taxafile.txt --count-matrix-file $dir/count-matrix.txt --entropy $dir/entropy.txt --species-file $dir/species-file.txt $(echo $(ls data/*))

--- a/run.sh
+++ b/run.sh
@@ -12,7 +12,7 @@ do
 	echo $treefile 
 	basename=${treefile%.newick}
 	dir="$basename-$1-$2"
-	mkdir "$dir"
+	mkdir -p "$dir"
 	cd "$dir"
 	../../parse-newick/newick "../$NEWICK_DIR/$treefile"
 	../../parse-newick/relabel-tree.py --treefile "out.tree" --species-file "species_file" --relabel-file "../$MATRIX_DIR/species-file.txt" --out final.tree


### PR DESCRIPTION
## Description
scripts previously exited with error if a directory that it was trying to make already existed. This commit changes that behavior by creating directories using `mkdir -p` flag.
