### PR TITLE
mv files to the directory instead of moving the directory

### DIFF
--- a/ecoli/download-ecoli.sh
+++ b/ecoli/download-ecoli.sh
@@ -3,5 +3,7 @@
 curl "https://afproject.org/media/genome/std/assembled/ecoli/dataset/assembled-ecoli.zip" \
 	--output ecoli.zip
 unzip ecoli.zip
-mv assembled-ecoli data
+mkdir -p data
+mv assembled-ecoli/* data
+rm -rf assembled-ecoli
 

--- a/fish/download-fish.sh
+++ b/fish/download-fish.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-curl "http://afproject.org/media/genome/std/assembled/fish_mito/dataset/assembled-fish_mito.zip" \
+curl "https://afproject.org/media/genome/std/assembled/fish_mito/dataset/assembled-fish_mito.zip" \
 	--output fish.zip
+mkdir -p data
 unzip fish.zip
-mv assembled-fish_mito data
+mv assembled-fish_mito/* data
+rm -rf assembled-fish_mito
 

--- a/plant/download-plant.sh
+++ b/plant/download-plant.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-curl "http://afproject.org/media/genome/std/assembled/plants/dataset/assembled-plants.zip" \
+curl "https://afproject.org/media/genome/std/assembled/plants/dataset/assembled-plants.zip" \
 	--output plant.zip
+mkdir -p data
 unzip plant.zip
-mv assembled-plant data
+mv assembled-plant/* data
+rm -rf assembled-plant
 


### PR DESCRIPTION
The directory might already exist when running inside docker with a volume. So we should move the files into the directory and not the directory itself.