### PR TITLE
fix newick lexer: exclude whitespace from WORD tokens and fix buffer …

### DIFF
--- a/parse-newick/newick.l
+++ b/parse-newick/newick.l
@@ -19,8 +19,8 @@ int column_offset = 1;
 
 %%
 [ \t\b\f\n\r\v] {}
-[^,:;\(\) \t\b\f\n\r\v][^,:;\(\)]* {
-	yylval.text = new char[sizeof(yytext)+1];
+[^,:;\(\) \t\b\f\n\r\v][^,:;\(\) \t\b\f\n\r\v]* {
+	yylval.text = new char[strlen(yytext)+1];
 	strcpy(yylval.text,yytext);
 	return WORD;
 	//printf("NAME: %s\n",yytext);


### PR DESCRIPTION
…allocation

The WORD rule's trailing character class was missing whitespace exclusions, allowing labels to consume whitespace. Also replaced sizeof(yytext) with strlen(yytext) for correct allocation size since yytext is a char*.

## Description

<!-- A few sentences describing the changes. Add test jenkins job URL (if have any) -->

## How to test?

- [ ] <!-- step to test change -->

## Reminders

- ...

Related PRs:
- ...
